### PR TITLE
Check if ID type implements `json.Unmarshaler`

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -5,14 +5,13 @@ import (
 	"time"
 )
 
-
 type AuthorID struct {
 	Value string
 }
 
 type Author struct {
-	ID AuthorID `jsonapi:"primary,authors"`
-	Name string `jsonapi:"attr,name"`
+	ID   AuthorID `jsonapi:"primary,authors"`
+	Name string   `jsonapi:"attr,name"`
 }
 
 func (id *AuthorID) UnmarshalJSON(arr []byte) error {
@@ -26,8 +25,9 @@ func (id *AuthorID) UnmarshalJSON(arr []byte) error {
 }
 
 type SomethingWithJsonUnmarshallerAttr struct {
-	ID   string       `jsonapi:"primary,somethings"`
-	AuthorID AuthorID `jsonapi:"attr,authorId"`
+	ID           string     `jsonapi:"primary,somethings"`
+	AuthorID     AuthorID   `jsonapi:"attr,authorId"`
+	OtherAuthors []AuthorID `jsonapi:"attr,otherAuthors"`
 }
 
 type BadModel struct {
@@ -57,17 +57,17 @@ type Timestamp struct {
 }
 
 type Timestamps struct {
-	ID   int        `jsonapi:"primary,timestamp-arrays"`
+	ID   int          `jsonapi:"primary,timestamp-arrays"`
 	Time []time.Time  `jsonapi:"attr,timestamps,iso8601"`
 	Next []*time.Time `jsonapi:"attr,next,iso8601"`
 }
 
 type NumberArrays struct {
-	ID   int        	`jsonapi:"primary,number-arrays"`
-	Ints []int  		`jsonapi:"attr,ints"`
-	UInts []uint 		`jsonapi:"attr,uints"`
-	Floats []float32 	`jsonapi:"attr,floats"`
-	Doubles []float64 	`jsonapi:"attr,doubles"`
+	ID      int       `jsonapi:"primary,number-arrays"`
+	Ints    []int     `jsonapi:"attr,ints"`
+	UInts   []uint    `jsonapi:"attr,uints"`
+	Floats  []float32 `jsonapi:"attr,floats"`
+	Doubles []float64 `jsonapi:"attr,doubles"`
 }
 
 type Car struct {

--- a/models_test.go
+++ b/models_test.go
@@ -25,9 +25,10 @@ func (id *AuthorID) UnmarshalJSON(arr []byte) error {
 }
 
 type SomethingWithJsonUnmarshallerAttr struct {
-	ID           string     `jsonapi:"primary,somethings"`
-	AuthorID     AuthorID   `jsonapi:"attr,authorId"`
-	OtherAuthors []AuthorID `jsonapi:"attr,otherAuthors"`
+	ID              string      `jsonapi:"primary,somethings"`
+	AuthorID        AuthorID    `jsonapi:"attr,authorId"`
+	OtherAuthors    []AuthorID  `jsonapi:"attr,otherAuthors"`
+	OtherAuthorsPtr []*AuthorID `jsonapi:"attr,otherPtrAuthors"`
 }
 
 type BadModel struct {

--- a/models_test.go
+++ b/models_test.go
@@ -25,6 +25,11 @@ func (id *AuthorID) UnmarshalJSON(arr []byte) error {
 	return nil
 }
 
+type SomethingWithJsonUnmarshallerAttr struct {
+	ID   string       `jsonapi:"primary,somethings"`
+	AuthorID AuthorID `jsonapi:"attr,authorId"`
+}
+
 type BadModel struct {
 	ID int `jsonapi:"primary"`
 }

--- a/models_test.go
+++ b/models_test.go
@@ -5,6 +5,26 @@ import (
 	"time"
 )
 
+
+type AuthorID struct {
+	Value string
+}
+
+type Author struct {
+	ID AuthorID `jsonapi:"primary,authors"`
+	Name string `jsonapi:"attr,name"`
+}
+
+func (id *AuthorID) UnmarshalJSON(arr []byte) error {
+	// Copy byte array to ensure that we keep the value
+	str := make([]byte, len(arr), len(arr))
+	copy(str, arr)
+
+	id.Value = string(str[:])
+
+	return nil
+}
+
 type BadModel struct {
 	ID int `jsonapi:"primary"`
 }

--- a/models_test.go
+++ b/models_test.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -22,6 +23,16 @@ func (id *AuthorID) UnmarshalJSON(arr []byte) error {
 	id.Value = string(str[:])
 
 	return nil
+}
+
+func (id *AuthorID) MarshalJSON() ([]byte, error) {
+	var val = id.Value
+	return json.Marshal(&val)
+}
+
+type SomethingWithJsonUnmarshallerPtrAttr struct {
+	ID              string      `jsonapi:"primary,somethings"`
+	OtherAuthorsPtr []*AuthorID `jsonapi:"attr,otherPtrAuthors"`
 }
 
 type SomethingWithJsonUnmarshallerAttr struct {
@@ -76,6 +87,13 @@ type Car struct {
 	Make  *string `jsonapi:"attr,make,omitempty"`
 	Model *string `jsonapi:"attr,model,omitempty"`
 	Year  *uint   `jsonapi:"attr,year,omitempty"`
+}
+
+type CarAuthorID struct {
+	ID    *AuthorID `jsonapi:"primary,cars"`
+	Make  *string   `jsonapi:"attr,make,omitempty"`
+	Model *string   `jsonapi:"attr,model,omitempty"`
+	Year  *uint     `jsonapi:"attr,year,omitempty"`
 }
 
 type Post struct {

--- a/request.go
+++ b/request.go
@@ -377,12 +377,13 @@ func unmarshalValue(fieldValue, v reflect.Value, fieldType reflect.Type, iso8601
 		values := reflect.MakeSlice(reflect.SliceOf(t.Elem()), v.Len(), v.Len())
 
 		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i).Interface()
 			switch fieldValue.Type().Elem() {
 
 			case reflect.TypeOf(time.Time{}):
 				t := time.Time{}
 				value := reflect.ValueOf(&t)
-				e := unmarshalTime(reflect.ValueOf(v.Index(i).Interface().(string)), value.Elem(), iso8601)
+				e := unmarshalTime(reflect.ValueOf(val.(string)), value.Elem(), iso8601)
 				if e != nil {
 					return e
 				}
@@ -392,7 +393,7 @@ func unmarshalValue(fieldValue, v reflect.Value, fieldType reflect.Type, iso8601
 			case reflect.TypeOf(new(time.Time)):
 				t := new(time.Time)
 				value := reflect.ValueOf(&t)
-				e := unmarshalTimePtr(reflect.ValueOf(v.Index(i).Interface().(string)), value.Elem(), iso8601)
+				e := unmarshalTimePtr(reflect.ValueOf(val.(string)), value.Elem(), iso8601)
 				if e != nil {
 					return e
 				}
@@ -401,33 +402,31 @@ func unmarshalValue(fieldValue, v reflect.Value, fieldType reflect.Type, iso8601
 				continue
 			}
 
+			// Check if the ID Type implements json.Unmarshaler
+			obj := reflect.New(fieldValue.Type().Elem())
+
+			if unmarshaler, ok := obj.Interface().(json.Unmarshaler); ok {
+				str := val.(string)
+				unmarshalError := unmarshaler.UnmarshalJSON([]byte(str))
+				if unmarshalError != nil {
+					return ErrInvalidType
+				}
+
+				values.Index(i).Set(obj.Elem())
+				continue
+			}
+
 			switch sliceType.Kind() {
 			case reflect.String:
-				values.Index(i).Set(reflect.ValueOf(v.Index(i).Interface()))
+				values.Index(i).Set(reflect.ValueOf(val))
 				continue
-			case reflect.Int:
-				var num = 0
-				value := reflect.ValueOf(&num)
-				unmarshalNumber(reflect.ValueOf(v.Index(i).Interface()), value.Elem(), t.Elem())
-				values.Index(i).Set(reflect.ValueOf(num))
-				continue
-			case reflect.Uint:
-				var num uint = 0
-				value := reflect.ValueOf(&num)
-				unmarshalNumber(reflect.ValueOf(v.Index(i).Interface()), value.Elem(), t.Elem())
-				values.Index(i).Set(reflect.ValueOf(num))
-				continue
-			case reflect.Float32:
-				var num float32 = 0
-				value := reflect.ValueOf(&num)
-				unmarshalNumber(reflect.ValueOf(v.Index(i).Interface()), value.Elem(), t.Elem())
-				values.Index(i).Set(reflect.ValueOf(num))
-				continue
-			case reflect.Float64:
-				var num float64 = 0
-				value := reflect.ValueOf(&num)
-				unmarshalNumber(reflect.ValueOf(v.Index(i).Interface()), value.Elem(), t.Elem())
-				values.Index(i).Set(reflect.ValueOf(num))
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8,
+				reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+				e := unmarshalNumber(reflect.ValueOf(val), values.Index(i), fieldValue.Type().Elem())
+				if e != nil {
+					return e
+				}
+
 				continue
 			}
 		}

--- a/request.go
+++ b/request.go
@@ -185,6 +185,19 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 				continue
 			}
 
+			// Check if the ID Type implements json.Unmarshaler
+			obj := reflect.New(fieldValue.Type())
+			if unmarshaler, ok := obj.Interface().(json.Unmarshaler); ok {
+				unmarshalError := unmarshaler.UnmarshalJSON([]byte(data.ID))
+				if unmarshalError != nil {
+					er = ErrBadJSONAPIID
+					break
+				}
+
+				assign(fieldValue, obj.Elem())
+				continue
+			}
+
 			// Value was not a string... only other supported type was a numeric,
 			// which would have been sent as a float value.
 			floatValue, err := strconv.ParseFloat(data.ID, 64)

--- a/request.go
+++ b/request.go
@@ -403,7 +403,14 @@ func unmarshalValue(fieldValue, v reflect.Value, fieldType reflect.Type, iso8601
 			}
 
 			// Check if the ID Type implements json.Unmarshaler
-			obj := reflect.New(fieldValue.Type().Elem())
+			unmarshalable := fieldValue.Type().Elem()
+
+			var obj reflect.Value
+			if unmarshalable.Kind() == reflect.Ptr {
+				obj = reflect.New(unmarshalable.Elem())
+			} else {
+				obj = reflect.New(unmarshalable)
+			}
 
 			if unmarshaler, ok := obj.Interface().(json.Unmarshaler); ok {
 				str := val.(string)
@@ -412,7 +419,12 @@ func unmarshalValue(fieldValue, v reflect.Value, fieldType reflect.Type, iso8601
 					return ErrInvalidType
 				}
 
-				values.Index(i).Set(obj.Elem())
+				if unmarshalable.Kind() == reflect.Ptr {
+					values.Index(i).Set(obj.Elem().Addr())
+				} else {
+					values.Index(i).Set(obj.Elem())
+				}
+
 				continue
 			}
 

--- a/request.go
+++ b/request.go
@@ -457,6 +457,20 @@ func unmarshalValue(fieldValue, v reflect.Value, fieldType reflect.Type, iso8601
 		return unmarshalPtr(v, fieldValue)
 	}
 
+	// Check if the ID Type implements json.Unmarshaler
+	obj := reflect.New(fieldValue.Type())
+	if unmarshaler, ok := obj.Interface().(json.Unmarshaler); ok {
+		str := v.Interface().(string)
+
+		unmarshalError := unmarshaler.UnmarshalJSON([]byte(str))
+		if unmarshalError != nil {
+			return ErrInvalidType
+		}
+
+		assign(fieldValue, obj.Elem())
+		return nil
+	}
+
 	// As a final catch-all, ensure types line up to avoid a runtime panic.
 	if fieldValue.Kind() != v.Kind() {
 		return ErrInvalidType

--- a/request_test.go
+++ b/request_test.go
@@ -382,6 +382,41 @@ func TestUnmarshalParsesUnmarshallerArray(t *testing.T) {
 	}
 }
 
+func TestUnmarshalParsesUnmarshallerPtrArray(t *testing.T) {
+	id := "111111"
+	out := &SomethingWithJsonUnmarshallerAttr{}
+	authors := []string{
+		"4",
+		"5",
+	}
+
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "somethings",
+			"id":   id,
+			"attributes": map[string]interface{}{
+				"otherPtrAuthors": authors,
+			},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UnmarshalPayload(bytes.NewReader(b), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if authors[0] != out.OtherAuthorsPtr[0].Value {
+		t.Fatalf("Was expecting %d, got %d", authors[0], out.OtherAuthors[0].Value)
+	}
+
+	if authors[1] != out.OtherAuthorsPtr[1].Value {
+		t.Fatalf("Was expecting %d, got %d", authors[1], out.OtherAuthors[1].Value)
+	}
+}
+
 func TestUnmarshalParsesUIntArray(t *testing.T) {
 	uints := []uint{
 		1,

--- a/request_test.go
+++ b/request_test.go
@@ -31,7 +31,7 @@ func TestUnmarshal_idUnmarshalerInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if id != out.ID.Value  {
+	if id != out.ID.Value {
 		t.Fatalf("Was expecting %d, got %d", id, out.ID.Value)
 	}
 }
@@ -41,8 +41,8 @@ func TestUnmarshal_attrUnmarshalerInterface(t *testing.T) {
 	out := &SomethingWithJsonUnmarshallerAttr{}
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
-			"type":       "somethings",
-			"id":         "ddasd",
+			"type": "somethings",
+			"id":   "ddasd",
 			"attributes": map[string]interface{}{
 				"authorId": id,
 			},
@@ -57,7 +57,7 @@ func TestUnmarshal_attrUnmarshalerInterface(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if id != out.AuthorID.Value  {
+	if id != out.AuthorID.Value {
 		t.Fatalf("Was expecting %d, got %d", id, out.AuthorID.Value)
 	}
 }
@@ -315,7 +315,7 @@ func TestUnmarshalSetsAttrs(t *testing.T) {
 }
 
 func TestUnmarshalParsesIntArray(t *testing.T) {
-	ints := []int {
+	ints := []int{
 		1,
 		2,
 	}
@@ -347,8 +347,43 @@ func TestUnmarshalParsesIntArray(t *testing.T) {
 	}
 }
 
+func TestUnmarshalParsesUnmarshallerArray(t *testing.T) {
+	id := "111111"
+	out := &SomethingWithJsonUnmarshallerAttr{}
+	authors := []string{
+		"4",
+		"5",
+	}
+
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "somethings",
+			"id":   id,
+			"attributes": map[string]interface{}{
+				"otherAuthors": authors,
+			},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UnmarshalPayload(bytes.NewReader(b), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if authors[0] != out.OtherAuthors[0].Value {
+		t.Fatalf("Was expecting %d, got %d", authors[0], out.OtherAuthors[0].Value)
+	}
+
+	if authors[1] != out.OtherAuthors[1].Value {
+		t.Fatalf("Was expecting %d, got %d", authors[1], out.OtherAuthors[1].Value)
+	}
+}
+
 func TestUnmarshalParsesUIntArray(t *testing.T) {
-	uints := []uint {
+	uints := []uint{
 		1,
 		2,
 	}
@@ -381,7 +416,7 @@ func TestUnmarshalParsesUIntArray(t *testing.T) {
 }
 
 func TestUnmarshalParsesFloatArray(t *testing.T) {
-	floats := []float32 {
+	floats := []float32{
 		1.5,
 		2.4,
 	}
@@ -413,9 +448,8 @@ func TestUnmarshalParsesFloatArray(t *testing.T) {
 	}
 }
 
-
 func TestUnmarshalParsesISO8601Array(t *testing.T) {
-	timestamps := []string {
+	timestamps := []string{
 		"2016-08-17T08:27:12Z",
 		"2016-08-18T08:27:12Z",
 	}
@@ -451,7 +485,7 @@ func TestUnmarshalParsesISO8601Array(t *testing.T) {
 }
 
 func TestUnmarshalParsesISO8601TimePointerArray(t *testing.T) {
-	timestamps := []string {
+	timestamps := []string{
 		"2016-08-17T08:27:12Z",
 		"2016-08-18T08:27:12Z",
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -36,6 +36,32 @@ func TestUnmarshal_idUnmarshalerInterface(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_attrUnmarshalerInterface(t *testing.T) {
+	id := "111111"
+	out := &SomethingWithJsonUnmarshallerAttr{}
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type":       "somethings",
+			"id":         "ddasd",
+			"attributes": map[string]interface{}{
+				"authorId": id,
+			},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UnmarshalPayload(bytes.NewReader(b), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if id != out.AuthorID.Value  {
+		t.Fatalf("Was expecting %d, got %d", id, out.AuthorID.Value)
+	}
+}
+
 func TestUnmarshall_attrStringSlice(t *testing.T) {
 	out := &Book{}
 	tags := []string{"fiction", "sale"}

--- a/request_test.go
+++ b/request_test.go
@@ -12,6 +12,30 @@ import (
 	"time"
 )
 
+func TestUnmarshal_idUnmarshalerInterface(t *testing.T) {
+	id := "111111"
+	out := &Author{}
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type":       "authors",
+			"id":         id,
+			"attributes": map[string]interface{}{"name": "some name"},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UnmarshalPayload(bytes.NewReader(b), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if id != out.ID.Value  {
+		t.Fatalf("Was expecting %d, got %d", id, out.ID.Value)
+	}
+}
+
 func TestUnmarshall_attrStringSlice(t *testing.T) {
 	out := &Book{}
 	tags := []string{"fiction", "sale"}

--- a/response.go
+++ b/response.go
@@ -255,7 +255,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				if marshalError != nil {
 					er = ErrBadJSONAPIID
 				}
-				node.ID = string(marshalResult[1 : len(marshalResult)-1])
+				node.ID = string(marshalResult[:])
 			} else {
 				// Handle allowed types
 				switch kind {

--- a/response_test.go
+++ b/response_test.go
@@ -215,12 +215,91 @@ func TestMarshalIDPtr(t *testing.T) {
 	// attributes := data["attributes"].(map[string]interface{})
 
 	// Verify that the ID was sent
-	val, exists := data["id"]
+	val, exists := data["id"].(string)
 	if !exists {
 		t.Fatal("Was expecting the data.id member to exist")
 	}
 	if val != id {
 		t.Fatalf("Was expecting the data.id member to be `%s`, got `%s`", id, val)
+	}
+}
+
+func TestMarshalIDMarshallerPtr(t *testing.T) {
+	id := AuthorID{
+		Value: "123e4567-e89b-12d3-a456-426655440000",
+	}
+	make, model := "Ford", "Mustang"
+	car := &CarAuthorID{
+		ID:    &id,
+		Make:  &make,
+		Model: &model,
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, car); err != nil {
+		t.Fatal(err)
+	}
+
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &jsonData); err != nil {
+		t.Fatal(err)
+	}
+	data := jsonData["data"].(map[string]interface{})
+
+	// Verify that the ID was sent
+	val, exists := data["id"]
+	if !exists {
+		t.Fatal("Was expecting the data.id member to exist")
+	}
+
+	if val != id.Value {
+		t.Fatalf("Was expecting the data.id member to be `%s`, got `%s`", id, val)
+	}
+}
+
+func TestMarshallerPtrArray(t *testing.T) {
+	id1 := "111111"
+	id2 := "222222"
+
+	authors := []*AuthorID{
+		{
+			Value: id1,
+		},
+		{
+			Value: id2,
+		},
+	}
+
+	in := &SomethingWithJsonUnmarshallerPtrAttr{
+		ID:              "foo",
+		OtherAuthorsPtr: authors,
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, in); err != nil {
+		t.Fatal(err)
+	}
+
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &jsonData); err != nil {
+		t.Fatal(err)
+	}
+
+	data := jsonData["data"].(map[string]interface{})
+	attributes := data["attributes"].(map[string]interface{})
+	// Verify that the ID was sent
+	val, exists := attributes["otherPtrAuthors"].([]interface{})
+
+	if !exists {
+		t.Fatal("Was expecting the data.attributes.otherPtrAuthors member to exist")
+	}
+
+	if val[0] != authors[0].Value {
+		t.Fatalf("Was expecting %d, got %d", authors[0].Value, val[0])
+	}
+
+	if val[1] != authors[1].Value {
+		t.Fatalf("Was expecting %d, got %d", authors[1].Value, val[1])
 	}
 }
 


### PR DESCRIPTION
For custom ID types, it's nice to be able to deserialize the ID in the
way that you want.