### PR TITLE
Improve unmarshaler support

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -15,6 +15,11 @@ type Author struct {
 	Name string   `jsonapi:"attr,name"`
 }
 
+type AuthorPtr struct {
+	ID   *AuthorID `jsonapi:"primary,authors-ptr"`
+	Name string   `jsonapi:"attr,name"`
+}
+
 func (id *AuthorID) UnmarshalJSON(arr []byte) error {
 	// Copy byte array to ensure that we keep the value
 	str := make([]byte, len(arr), len(arr))
@@ -25,7 +30,7 @@ func (id *AuthorID) UnmarshalJSON(arr []byte) error {
 	return nil
 }
 
-func (id *AuthorID) MarshalJSON() ([]byte, error) {
+func (id AuthorID) MarshalJSON() ([]byte, error) {
 	var val = id.Value
 	return json.Marshal(&val)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -36,6 +36,30 @@ func TestUnmarshal_idUnmarshalerInterface(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_idUnmarshalerPtrInterface(t *testing.T) {
+	id := "111111"
+	out := &AuthorPtr{}
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type":       "authors-ptr",
+			"id":         id,
+			"attributes": map[string]interface{}{"name": "some name"},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UnmarshalPayload(bytes.NewReader(b), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if id != out.ID.Value {
+		t.Fatalf("Was expecting %d, got %d", id, out.ID.Value)
+	}
+}
+
 func TestUnmarshal_attrUnmarshalerInterface(t *testing.T) {
 	id := "111111"
 	out := &SomethingWithJsonUnmarshallerAttr{}


### PR DESCRIPTION
Now a pointer of a type that implements `json.Unmarshaler` can actually be... unmarshaled.